### PR TITLE
Add defer attributes to scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,16 +7,16 @@
     <title>Roiban - CV</title>
     <link rel="stylesheet" href="./public/styles.css">
     <link rel="stylesheet" href="./public/posts.css">
-    <script src="https://unpkg.com/htmx.org@1.9.10"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-javascript.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-c.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-cpp.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-java.min.js"></script>
-    <script src="./src/diffusion.js"></script>
-    <script src="./src/popup.js"></script>
-    <script src="./src/posts.js"></script>
+    <script src="https://unpkg.com/htmx.org@1.9.10" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-javascript.min.js" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-c.min.js" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-cpp.min.js" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-java.min.js" defer></script>
+    <script src="./src/diffusion.js" defer></script>
+    <script src="./src/popup.js" defer></script>
+    <script src="./src/posts.js" defer></script>
 </head>
 <body>
     <div class="container">


### PR DESCRIPTION
## Summary
- improve page load behavior by deferring htmx, Prism, and local JS files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68415ece3914832ba3a73cb282881acb